### PR TITLE
Testnet Auxpow start block

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -181,7 +181,7 @@ public:
         consensus.nMajorityWindow = 100;
         consensus.fPowAllowMinDifficultyBlocks = true;
         
-        consensus.nStartAuxPow = 1402000;
+        consensus.nStartAuxPow = 150;
         consensus.nAuxpowChainId = 0x005A; 
         consensus.fStrictChainId = false;
         


### PR DESCRIPTION
In 9.2.17 I see:

AUXPOW_START_TESTNET = 175

listed in core.h