### PR TITLE
Proposed change to default BLOCK_MAX_SIZE

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -48,7 +48,7 @@ class CValidationState;
 struct CNodeStateStats;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 200000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;


### PR DESCRIPTION
This is a proposed change to prevent a spam attack. An attacker would need to be a miner to needlessly fill blocks. Individual miners should be able to change this if desired.

Alternatively, we could look at adjusting fees, but seems to be not as straight forward?