### PR TITLE
uri revert to myriadcoin

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -199,7 +199,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
 
 QString formatBitcoinURI(const SendCoinsRecipient &info)
 {
-    QString ret = QString("myriad:%1").arg(info.address);
+    QString ret = QString("myriadcoin:%1").arg(info.address);
     int paramCount = 0;
 
     if (info.amount)


### PR DESCRIPTION
many older services used "myriadcoin" in the uri, this was changed in 0.11.2