### PR TITLE
Proposal: 75% vs 95% for BIP9 deployments

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -114,7 +114,7 @@ public:
         consensus.nFork1MinBlock = 1764000; // minimum block height where fork 1 takes effect (algo switch, seq algo count change)
         
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
+        consensus.nRuleChangeActivationThreshold = 1512; // 75% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008


### PR DESCRIPTION
Since 75% would be the equivalent of ~95% of 4/5 algos, should this be acceptable?