### PR TITLE
MIP2 - Reserve algo ids

### DIFF
--- a/doc/mip2.md
+++ b/doc/mip2.md
@@ -1,0 +1,29 @@
+MIP 2: Reserver algorithm bits
+
+Status: Under development
+
+
+
+Motivation
+
+
+Myriad uses bits in the nVersion field to indicate which
+PoW algorithm is used.
+
+Currently algo id 6 and 7 defaults to using SHA256d.
+
+For future use of these ids, blocks currently valid
+(using id 6 or 7 with SHA256d) should instead not 
+be accepted as valid by the network. 
+
+
+
+Implementation
+
+Deployment of this rule is through version bit 4.
+
+
+
+Reference implementation
+
+https://github.com/myriadteam/myriadcoin/tree/mip2

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -111,6 +111,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nStartTime = 1507420800; // October 8th, 2017
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nTimeout = 1538956800; // October 8th, 2018
 
+        // Deployment of MIP2 (Reserve algorithm ids)
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 4;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1517443200; // Feb 1st, 2018
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 1548979200; // Feb 1st, 2019
+
         /*** Upstream Chainparams ***/
 
         consensus.nSubsidyHalvingInterval = 80640 * 12;
@@ -270,6 +275,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nStartTime = 1504224000; // September 1st, 2017
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nTimeout = 1535760000; // September 1st, 2018
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 4;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1517443200; // Feb 1st, 2018
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 1548979200; // Feb 1st, 2019
 
         /*** Upstream Chainparams ***/
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -113,7 +113,7 @@ public:
 
         // Deployment of MIP2 (Reserve algorithm ids)
         consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 4;
-        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1517443200; // Feb 1st, 2018
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1516320000; // Jan 19th, 2018
         consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 1548979200; // Feb 1st, 2019
 
         /*** Upstream Chainparams ***/
@@ -277,7 +277,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nTimeout = 1535760000; // September 1st, 2018
 
         consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 4;
-        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1517443200; // Feb 1st, 2018
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1516320000; // Jan 19th, 2018
         consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 1548979200; // Feb 1st, 2019
 
         /*** Upstream Chainparams ***/

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -408,6 +408,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_LEGBIT].nTimeout = 999999999999ULL;
 
+        // Deployment of MIP2 (Reserve algorithm ids)
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 4;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 0; 
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 999999999999ULL;
+
         /*** Upstream Chainparams ***/
 
         consensus.nSubsidyHalvingInterval = 150;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -18,6 +18,7 @@ enum DeploymentPos
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     DEPLOYMENT_LEGBIT, // Deployment of Legacy Bits.
+    DEPLOYMENT_RESERVEALGO, // Deployment of MIP2 (Reserve algos)
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1229,6 +1229,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BIP9SoftForkDescPushBack(bip9_softforks, "csv", consensusParams, Consensus::DEPLOYMENT_CSV);
     BIP9SoftForkDescPushBack(bip9_softforks, "segwit", consensusParams, Consensus::DEPLOYMENT_SEGWIT);
     BIP9SoftForkDescPushBack(bip9_softforks, "legbit", consensusParams, Consensus::DEPLOYMENT_LEGBIT);
+    BIP9SoftForkDescPushBack(bip9_softforks, "reservealgo", consensusParams, Consensus::DEPLOYMENT_RESERVEALGO);
     obj.push_back(Pair("softforks",             softforks));
     obj.push_back(Pair("bip9_softforks", bip9_softforks));
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3094,6 +3094,13 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
             return state.Invalid(false, REJECT_INVALID, "invalid-algo", "invalid YESCRYPT block");
     }
 
+    bool bMIP2 = (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_RESERVEALGO, versionbitscache) == THRESHOLD_ACTIVE);
+    if (bMIP2)
+    {
+        if (algo >= 6)
+            return state.Invalid(false, REJECT_INVALID, "invalid-algo", "invalid algo id");
+    }
+
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -22,6 +22,10 @@ const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION
     {
         /*.name =*/ "legbit",
         /*.gbt_force =*/ true,
+    },
+    {
+        /*.name =*/ "reservealgo",
+        /*.gbt_force =*/ true,
     }
 };
 


### PR DESCRIPTION
MIP2 reserves algo ids 6 and 7 by rejecting blocks with these ids.

This needs to be deployed before MIP1.
