### PR TITLE
MIP1: Change personalization back to Zcash upstream

### DIFF
--- a/src/crypto/equihash/equihash.cpp
+++ b/src/crypto/equihash/equihash.cpp
@@ -34,9 +34,9 @@ int Equihash<N,K>::InitialiseState(eh_HashState& base_state)
     uint32_t le_N = htole32(N);
     uint32_t le_K = htole32(K);
     unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
-    memcpy(personalization, "Myriadcoin", 10);
-    memcpy(personalization+10,  &le_N, 4);
-    memcpy(personalization+14, &le_K, 4);
+    memcpy(personalization, "ZMYR1PoW", 8);
+    memcpy(personalization+8,  &le_N, 4);
+    memcpy(personalization+12, &le_K, 4);
     return crypto_generichash_blake2b_init_salt_personal(&base_state,
                                                          NULL, 0, // No key.
                                                          (512/N)*N/8,

--- a/src/crypto/equihash/equihash.cpp
+++ b/src/crypto/equihash/equihash.cpp
@@ -34,7 +34,7 @@ int Equihash<N,K>::InitialiseState(eh_HashState& base_state)
     uint32_t le_N = htole32(N);
     uint32_t le_K = htole32(K);
     unsigned char personalization[crypto_generichash_blake2b_PERSONALBYTES] = {};
-    memcpy(personalization, "ZMYR1PoW", 8);
+    memcpy(personalization, "ZcashPoW", 8);
     memcpy(personalization+8,  &le_N, 4);
     memcpy(personalization+12, &le_K, 4);
     return crypto_generichash_blake2b_init_salt_personal(&base_state,


### PR DESCRIPTION
After discussing with roarde, and from what I see here

https://github.com/jedisct1/libsodium/blob/master/src/libsodium/include/sodium/crypto_generichash_blake2b.h#L66

it may be necessary to make this standard length with Zcash... however I still think it's worthwhile to not use the value from upstream in order to at least make blind profit switching pools not possible... thoughts? The `Z` in `ZMYR1PoW` is an attempt at deference to upstream.