### PR TITLE
Always follow testnet checkpoints

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -381,7 +381,7 @@ public:
         consensus.nMinimumChainWork = uint256S("0x00");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0xff983c72147a81ac5b8ebfc68b62b39358cac4b8eb5518242e87f499b71c6a51"); // 1
+        consensus.defaultAssumeValid = uint256S("0x000000c00310153e400312a5f10a51c14abd4d4456ad92a8efcb516c7c00fde5"); // 26607
 
         pchMessageStart[0] = 0x01;
         pchMessageStart[1] = 0xf5;
@@ -418,15 +418,16 @@ public:
 
         checkpointData = {
             {
-                {   0, uint256S("0000017ce2a79c8bddafbbe47c004aa92b20678c354b34085f62b762084b9788")},
-                { 800, uint256S("00000071942cef6d87635a92f106d5b1935b1314538af80922c766487afd8b22")},
+                {     0, uint256S("0000017ce2a79c8bddafbbe47c004aa92b20678c354b34085f62b762084b9788")},
+                {   800, uint256S("00000071942cef6d87635a92f106d5b1935b1314538af80922c766487afd8b22")},
+                { 26607, uint256S("000000c00310153e400312a5f10a51c14abd4d4456ad92a8efcb516c7c00fde5")},
             }
         };
 
         chainTxData = ChainTxData{
-            // Data as of block 00000071942cef6d87635a92f106d5b1935b1314538af80922c766487afd8b22 (height 800)
-            1504107501,
-            817,
+            // Data as of block 000000c00310153e400312a5f10a51c14abd4d4456ad92a8efcb516c7c00fde5 (height 26607)
+            1549032928,
+            26673,
             0.02
         };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1992,6 +1992,13 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         }
     }
 
+    // Myriadcoin: always follow testnet checkpoints:
+    if (chainparams.NetworkIDString() == "test") {
+        CBlockIndex* pcheckpoint = Checkpoints::GetLastCheckpoint(chainparams.Checkpoints());
+        if (pindex->nHeight == pcheckpoint->nHeight && block.GetHash() != *pcheckpoint->phashBlock)
+            return state.DoS(100, error("%s: forked chain hash different from checkpoint hash (height %d),", __func__,pcheckpoint->nHeight), REJECT_CHECKPOINT, "bad-fork-prior-to-checkpoint");
+    }
+
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = 0;
     if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV, versionbitscache) == THRESHOLD_ACTIVE) {


### PR DESCRIPTION
This appears to be currently necessary to put `testnet` in the same state as `mainnet` as there have been multiple unknown `bit 2` softforks on testnet, probably from inadvertent v0.14.2.5 testnet mining.

This should only affect `testnet`.