### PR TITLE
Revert "consensus: allow auxpow regtest blocks at genesis"

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -447,7 +447,7 @@ public:
         consensus.nPowTargetSpacingV2 = 60; // new target time for block spacing across all algorithms
         consensus.nAveragingInterval = 10; // number of blocks to take the timespan of
 
-        consensus.nStartAuxPow = 0;
+        consensus.nStartAuxPow = 150;
         consensus.nAuxpowChainId = 0x005A;
         consensus.fStrictChainId = false;
 


### PR DESCRIPTION
consensus: This reverts commit 808504a0539a9ff30735026428a0cdd6e1ab9ffb.

This was an unnecessary change to regtest consensus rules in #173 and can be implemented at a later date if necessary.

There is value in `0.14` - `0.18` regtest networks having the same consensus rules, so this is the easiest path.