### PR TITLE
Add COINiD DNS seed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -206,6 +206,7 @@ public:
         vSeeds.emplace_back("seed7.myriadcoin.org");
         vSeeds.emplace_back("seed8.myriadcoin.org");
         vSeeds.emplace_back("myriadseed1.cryptapus.org"); // cryptapus
+        vSeeds.emplace_back("xmy-seed1.coinid.org"); // COINiD
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,50);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,9);


### PR DESCRIPTION
Added our DNS seed.

Also found that some of the nodes (that the existing dns seeds are pointing to) does not seem to be reachable anymore. We might want to remove the inactive ones or contact the maintainers?

As a side note I forked bitnodes node crawler. So a list of reachable nodes can be found here: https://xmy-nodes.coinid.org/latest.json 